### PR TITLE
[fix]修复了删除用户所属部门时，departments字段不会删除的问题

### DIFF
--- a/src/views/personnel/user/index.vue
+++ b/src/views/personnel/user/index.vue
@@ -162,11 +162,10 @@
                   :normalizer="normalizer"
                   value-consists-of="ALL"
                   :multiple="true"
-                  flat="true"
+                  :flat="true"
                   no-children-text="没有更多选项"
                   no-results-text="没有匹配的选项"
                   @input="treeselectInput"
-                  @select="onOperatePersonChanged"
                 />
               </el-form-item>
             </el-col>
@@ -415,6 +414,29 @@ wLXapv+ZfsjG7NgdawIDAQAB
       this.dialogFormData.position = row.position
     },
 
+    // 将 部门id 转换为 部门name
+    setDepartmentNameByDepartmentId() {
+      const ids = this.dialogFormData.departmentId
+      if (!ids || !ids.length) return
+      const departments = []
+      // 深度优先遍函数
+      const dfs = (node, cb) => {
+        if (!node) return
+        cb(node)
+        if (node.children && node.children.length) {
+          node.children.forEach(item => {
+            dfs(item, cb)
+          })
+        }
+      }
+      dfs(this.departmentsOptions[0], node => {
+        if (ids.includes(node.ID)) {
+          departments.push(node.groupName)
+        }
+      })
+      this.dialogFormData.departments = departments.join(',')
+    },
+
     // 提交表单
     submitForm() {
       if (this.dialogFormData.nickname === '') {
@@ -476,7 +498,8 @@ wLXapv+ZfsjG7NgdawIDAQAB
       this.$refs['dialogForm'].validate(async valid => {
         if (valid) {
           this.submitLoading = true
-
+          // 在这里自动填充下部门字段
+          this.setDepartmentNameByDepartmentId()
           this.dialogFormDataCopy = { ...this.dialogFormData }
           if (this.dialogFormData.password !== '') {
           // 密码RSA加密处理
@@ -630,14 +653,6 @@ wLXapv+ZfsjG7NgdawIDAQAB
     treeselectInput(value) {
       this.treeselectValue = value
     },
-    onOperatePersonChanged(obj) {
-      // this.dialogFormData.departmentId = obj.ID
-      if (this.dialogFormData.departments === '') {
-        this.dialogFormData.departments = obj.groupName
-      } else {
-        this.dialogFormData.departments = this.dialogFormData.departments + ',' + obj.groupName
-      }
-    },
     syncDingTalkUsers(obj) {
       this.loading = true
       syncDingTalkUsersApi().then(res => {
@@ -689,7 +704,7 @@ wLXapv+ZfsjG7NgdawIDAQAB
       })
       this.getTableData()
       this.loading = false
-    },
+    }
   }
 }
 </script>


### PR DESCRIPTION
<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[fix]、[documentation] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- ☑️ 我已阅读并理解[贡献者指南]()。
- ☑️ 我已检查没有与此请求重复的拉取请求。
- ☑️ 我已经考虑过，并确认这份呈件对其他人很有价值。
- ☑️ 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

**填写PR内容：**

修复了删除用户所属部门时，departments字段不会删除的问题
使用该修复后，再次编辑出现异常的数据并且保存，异常数据会自动修复

**BUG复现方法**
人员管理 -> 用户管理 -> 挑选一个用户编辑 -> 编辑所属部门，并且重复勾选然后取消勾选部门 -> 触发bug, dialogFormData.departments 将会重复出现多次刚刚勾选的部门。并且提交表单时也会将错误的数据提交给服务器