### PR TITLE
✨ feat(api): 新增获取配置信息接口。

### DIFF
--- a/src/api/system/base.js
+++ b/src/api/system/base.js
@@ -1,5 +1,5 @@
 import request from '@/utils/request'
-//用户登录（已完成）
+// 用户登录（已完成）
 export function login(data) {
   return request({
     url: '/api/base/login',
@@ -14,10 +14,17 @@ export function refreshToken() {
     method: 'post'
   })
 }
-//用户退出接口（已完成）
+// 用户退出接口（已完成）
 export function logout() {
   return request({
     url: '/api/base/logout',
     method: 'post'
+  })
+}
+// 获取配置信息
+export function getConfig() {
+  return request({
+    url: '/api/base/config',
+    method: 'get'
   })
 }

--- a/src/views/personnel/user/index.vue
+++ b/src/views/personnel/user/index.vue
@@ -33,16 +33,16 @@
           <el-button :disabled="multipleSelection.length === 0" :loading="loading" icon="el-icon-upload2" type="success" @click="batchSync">批量同步</el-button>
         </el-form-item>
         <br>
-        <el-form-item>
+        <el-form-item v-if="syncConfig.ldapEnableSync">
           <el-button :loading="loading" icon="el-icon-download" type="warning" @click="syncOpenLdapUsers">同步原ldap用户信息</el-button>
         </el-form-item>
-        <el-form-item>
+        <el-form-item v-if="syncConfig.dingTalkEnableSync">
           <el-button :loading="loading" icon="el-icon-download" type="warning" @click="syncDingTalkUsers">同步钉钉用户信息</el-button>
         </el-form-item>
-        <el-form-item>
+        <el-form-item v-if="syncConfig.feiShuEnableSync">
           <el-button :loading="loading" icon="el-icon-download" type="warning" @click="syncFeiShuUsers">同步飞书用户信息</el-button>
         </el-form-item>
-        <el-form-item>
+        <el-form-item v-if="syncConfig.weComEnableSync">
           <el-button :loading="loading" icon="el-icon-download" type="warning" @click="syncWeComUsers">同步企业微信用户信息</el-button>
         </el-form-item>
       </el-form>
@@ -266,6 +266,7 @@ import { getUsers, createUser, updateUserById, batchDeleteUserByIds, changeUserS
 import { resetPassword } from '@/api/system/user'
 import { getRoles } from '@/api/system/role'
 import { getGroupTree } from '@/api/personnel/group'
+import { getConfig } from '@/api/system/base'
 import { Message } from 'element-ui'
 
 export default {
@@ -397,14 +398,32 @@ export default {
       // 重置密码结果对话框
       resetPasswordDialogVisible: false,
       newPassword: '',
-      resetUsername: ''
+      resetUsername: '',
+
+      // 同步配置
+      syncConfig: {
+        ldapEnableSync: false,
+        dingTalkEnableSync: false,
+        feiShuEnableSync: false,
+        weComEnableSync: false
+      }
     }
   },
   created() {
     this.getTableData()
     this.getRoles()
+    this.getSyncConfig()
   },
   methods: {
+    // 获取同步配置
+    async getSyncConfig() {
+      try {
+        const { data } = await getConfig()
+        this.syncConfig = data
+      } catch (error) {
+        console.error('获取同步配置失败:', error)
+      }
+    },
     // 查询
     search() {
       this.params.pageNum = 1


### PR DESCRIPTION
- 添加 `getConfig` 函数，用于从 `/api/base/config` 获取系统配置信息。

✨ feat(personnel): 根据同步配置动态显示表单项。

- 在 `group` 和 `user` 视图中，根据 `syncConfig` 动态控制 LDAP、钉钉、飞书、企业微信同步表单项的显示。
- 新增 `getSyncConfig` 方法，用于获取并存储同步配置。

<!-- 请务必在创建PR前，在右侧 Labels 选项中加上label的其中一个: [feature]、[fix]、[documentation] 。以便于Actions自动生成Releases时自动对PR进行归类。-->

**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [ ] 我已阅读并理解[贡献者指南]()。
- [ ] 我已检查没有与此请求重复的拉取请求。
- [ ] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [ ] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

**填写PR内容：**

-
-
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加动态同步配置支持，允许根据后端设置有条件地显示/隐藏LDAP、钉钉、飞书、企业微信等同步操作。

* **改进**
  * 增强了部分UI条件判断的严格性，提高了逻辑一致性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->